### PR TITLE
Add further unit tests for io.restassured.RestAssured

### DIFF
--- a/rest-assured/src/test/java/io/restassured/RestAssuredTest.java
+++ b/rest-assured/src/test/java/io/restassured/RestAssuredTest.java
@@ -16,7 +16,6 @@
 
 package io.restassured;
 
-import io.restassured.authentication.FormAuthConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -26,26 +25,14 @@ public class RestAssuredTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void formInputNotNullNullNullOutputIllegalArgumentException() {
-    // Arrange
-    final String userName = "    ";
-    final String password = null;
-    final FormAuthConfig config = null;
-    // Act
+  public void testForm() {
     thrown.expect(IllegalArgumentException.class);
-    RestAssured.form(userName, password, config);
+    RestAssured.form("user", null, null);
+    // Method is not expected to return due to exception thrown
+
+    thrown.expect(IllegalArgumentException.class);
+    RestAssured.form(null, "pw", null);
     // Method is not expected to return due to exception thrown
   }
 
-  @Test
-  public void formInputNullNotNullNullOutputIllegalArgumentException() {
-    // Arrange
-    final String userName = null;
-    final String password = "";
-    final FormAuthConfig config = null;
-    // Act
-    thrown.expect(IllegalArgumentException.class);
-    RestAssured.form(userName, password, config);
-    // Method is not expected to return due to exception thrown
-  }
 }

--- a/rest-assured/src/test/java/io/restassured/RestAssuredTest.java
+++ b/rest-assured/src/test/java/io/restassured/RestAssuredTest.java
@@ -16,6 +16,9 @@
 
 package io.restassured;
 
+import io.restassured.authentication.FormAuthConfig;
+import io.restassured.authentication.OAuthSignature;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -25,7 +28,15 @@ public class RestAssuredTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
+  public void testBasic() {
+    Assert.assertNotNull(RestAssured.basic("user", "pw"));
+  }
+
+  @Test
   public void testForm() {
+    Assert.assertNotNull(RestAssured.form("user", "pw"));
+    Assert.assertNotNull(RestAssured.form("user", "pw", new FormAuthConfig(null, null, null)));
+
     thrown.expect(IllegalArgumentException.class);
     RestAssured.form("user", null, null);
     // Method is not expected to return due to exception thrown
@@ -33,6 +44,35 @@ public class RestAssuredTest {
     thrown.expect(IllegalArgumentException.class);
     RestAssured.form(null, "pw", null);
     // Method is not expected to return due to exception thrown
+  }
+
+  @Test
+  public void testNtlm() {
+    Assert.assertNotNull(RestAssured.ntlm("user", "pw", "ws", "dom"));
+  }
+
+  @Test
+  public void testOauth() {
+    Assert.assertNotNull(RestAssured.oauth("cKey", "cSecret", "aToken", "sToken"));
+
+    final OAuthSignature signature = OAuthSignature.HEADER;
+    Assert.assertNotNull(RestAssured.oauth("cKey", "cSecret", "aToken", "sToken", signature));
+  }
+
+  @Test
+  public void testOauth2() {
+    Assert.assertNotNull(RestAssured.oauth2("aToken"));
+    Assert.assertNotNull(RestAssured.oauth2("aToken", OAuthSignature.HEADER));
+  }
+
+  @Test
+  public void testPreemptive() {
+    Assert.assertNotNull(RestAssured.preemptive());
+  }
+
+  @Test
+  public void testWithNoArgs() {
+    Assert.assertNotNull(RestAssured.withNoArgs());
   }
 
 }


### PR DESCRIPTION
Diffblue people: I've moved the previous old-style named tests for form() into a new test, testForm(), along with some new asserts. I've also added tests for other methods.

Hello. I've had another look at io.restassured.RestAssured and written some more unit tests with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes.